### PR TITLE
build: support aarch64-linux in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = [
         "x86_64-linux"
+        "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
       ];


### PR DESCRIPTION
Current flake does not support aarch64-linux (e.g. raspberry pi).

Result - if someone wants to add this plugin to their neovim using nix, and happens to use that neovim on an aarch64-linux system, their build/check fails.

This PR adds this system, but I may not be aware of any reasons for not including it in the first place.