### PR TITLE
fix: odd intermittent issue with load function

### DIFF
--- a/lua/lz/n/loader.lua
+++ b/lua/lz/n/loader.lua
@@ -103,8 +103,10 @@ end
 ---@param plugins string | lz.n.Plugin | string[] | lz.n.Plugin[]
 function M.load(plugins)
     plugins = (type(plugins) == "string" or plugins.name) and { plugins } or plugins
-    ---@param plugin string|lz.n.Plugin
-    vim.iter(plugins):each(function(plugin)
+    ---@cast plugins (string|lz.n.Plugin)[]
+    for _, plugin in pairs(plugins) do
+        -- NOTE: do not make this loop into vim.iter
+        -- https://github.com/nvim-neorocks/lz.n/pull/21
         local loadable = true
         if type(plugin) == "string" then
             if state.plugins[plugin] then
@@ -120,7 +122,7 @@ function M.load(plugins)
             M._load(plugin)
             hook("after", plugin)
         end
-    end)
+    end
 end
 
 return M


### PR DESCRIPTION
odd intermittent issue with load function when new handlers were added that only happened after adding vim.iter reverted to a version without the bug

fix for an issue I discovered in a new update

I should have put it as an issue or something but I found it and put my question here

I have ABSOLUTELY no idea why this is a bug. It looks like it does exactly the same thing. I am completely baffled. I get the error with one version and not with the other. Makes absolutely no sense to me. Regardless, we dont really need to call vim.iter just to go through a loop. But.. why though. Why does this error occur.

https://github.com/nvim-neorocks/lz.n/pull/17#issuecomment-2190957032