### PR TITLE
docs(contributing): update NixOS Wiki link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ We use the following tools:
 
 ### Nix devShell
 
-- Requires [flakes](https://nixos.wiki/wiki/Flakes) to be enabled.
+- Requires [flakes](https://wiki.nixos.org/wiki/Flakes) to be enabled.
 
 This project provides a `flake.nix` that can
 bootstrap all of the above development tools.


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️