### PR TITLE
feat: lz.n.Handler after_load field

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,13 @@ require("lz.n").register_handler(handler)
 |----------|------|-------------|
 | spec_field | `string` | the `lz.n.PluginSpec` field defined by the handler |
 | add | `fun(plugin: lz.n.Plugin)` | adds a plugin to the handler |
-| del | `fun(plugin: lz.n.Plugin)?` | removes a plugin from the handler |
+| del | `fun(plugin: lz.n.Plugin)?` | called before the `load` function for the plugin, should remove a plugin from the handler (unless `after_load` is used) |
+| after_load | `fun(plugin: lz.n.Plugin)?` | called AFTER the `load` function for the plugin, if used should delete the plugin from the handler instead of `del` |
 <!-- markdownlint-enable MD013 -->
+
+Once registered, the fields in custom handlers
+are called by lz.n with the plugin spec provided
+when plugins are added or loaded.
 
 When writing custom handlers,
 you can load the plugin and run the hooks from
@@ -352,8 +357,16 @@ the spec with the following function:
 ```
 
 The function accepts plugin names or parsed plugin specs.
+
 It will call the handler's `del` function (if it exists) after the `before` hooks,
-and before `load` of the plugin's spec.
+and before `load` of the plugin's spec. It should delete the plugin
+from the handler's state unless making use of `after_load`.
+
+It will likewise call the handler's `after_load` function (if it exists)
+after `load` and before `after` of the plugin's spec.
+The `after_load` function can be used to perform additional automatic
+loading logic from a handler after the main load function has been called.
+If used, should delete the plugin from the handler's state instead of del
 
 ### Extensions
 
@@ -363,7 +376,7 @@ Here are some examples for extending `lz.n`:
   A module loader that searches opt plugins
   and call `lz.n` hooks to ensure proper
   plugin initialisation.
-- [A custom `lz.n.Handler`](https://github.com/BirdeeHub/birdeeSystems/blob/a38a1c2d9b8d4b44382eba094d3504817c8a3296/common/birdeevim/lua/birdee/on_require.lua)
+- [A custom `lz.n.Handler`](https://github.com/nvim-neorocks/lz.n/discussions/25)
   that auto-loads on `require`, allowing users
   to specify modules.
 

--- a/lua/lz/n/handler/init.lua
+++ b/lua/lz/n/handler/init.lua
@@ -50,6 +50,15 @@ function M.disable(plugin)
     end)
 end
 
+function M.extra_load(plugin)
+    ---@param handler lz.n.Handler
+    vim.iter(handlers):each(function(_, handler)
+        if handler.after_load then
+            handler.after_load(plugin)
+        end
+    end)
+end
+
 ---@param plugins table<string, lz.n.Plugin>
 function M.init(plugins)
     ---@param plugin lz.n.Plugin

--- a/lua/lz/n/loader.lua
+++ b/lua/lz/n/loader.lua
@@ -22,6 +22,7 @@ function M._load(plugin)
     else
         vim.cmd.packadd(plugin.name)
     end
+    require("lz.n.handler").extra_load(plugin)
 end
 
 ---@param plugins table<string, lz.n.Plugin>

--- a/lua/lz/n/meta.lua
+++ b/lua/lz/n/meta.lua
@@ -92,6 +92,7 @@ error("Cannot import a meta module")
 --- @field spec_field string
 --- @field add fun(plugin: lz.n.Plugin)
 --- @field del? fun(plugin: lz.n.Plugin)
+--- @field after_load? fun(plugin: lz.n.Plugin)
 
 --- @type lz.n.Config
 vim.g.lz_n = vim.g.lz_n

--- a/spec/register_handler_spec.lua
+++ b/spec/register_handler_spec.lua
@@ -1,20 +1,48 @@
----@diagnostic disable: invisible
-vim.g.lz_n = {
-    load = function() end,
-}
 local lz_n = require("lz.n")
 local spy = require("luassert.spy")
 
 describe("handlers.custom", function()
+    ---@class state_entry
+    ---@field load_called boolean
+    ---@field after_load_called_after? boolean
+
+    ---@type table<string, state_entry>
+    local plugin_state = {}
+
     ---@class TestHandler: lz.n.Handler
     ---@type TestHandler
     local hndl = {
         spec_field = "testfield",
         add = function(_) end,
         del = function(_) end,
+        after_load = function(plugin)
+            if plugin_state[plugin.name] and plugin_state[plugin.name].load_called then
+                plugin_state[plugin.name] =
+                    vim.tbl_extend("error", plugin_state[plugin.name], { after_load_called_after = true })
+                return
+            end
+            plugin_state[plugin.name] =
+                vim.tbl_extend("error", plugin_state[plugin.name] or {}, { after_load_called_after = false })
+        end,
     }
+
+    local test_plugin = {
+        "testplugin",
+        testfield = { "a", "b" },
+        load = function(plugin)
+            plugin_state[plugin] = {
+                load_called = true,
+            }
+        end,
+    }
+    local test_plugin_loaded = vim.tbl_extend("error", test_plugin, { lazy = true })
+    test_plugin_loaded.name = test_plugin_loaded[1]
+    test_plugin_loaded[1] = nil
+
     local addspy = spy.on(hndl, "add")
     local delspy = spy.on(hndl, "del")
+    local afterspy = spy.on(hndl, "after_load")
+
     it("Duplicate handlers fail to register", function()
         local notispy = spy.new(function() end)
         -- NOTE: teardown fails if you don't temporarily replace vim.notify
@@ -26,22 +54,16 @@ describe("handlers.custom", function()
     end)
     it("can add plugins to the handler", function()
         assert.True(lz_n.register_handler(hndl))
-        lz_n.load({
-            "testplugin",
-            testfield = { "a", "b" },
-        })
-        assert.spy(addspy).called_with({
-            name = "testplugin",
-            testfield = { "a", "b" },
-            lazy = true,
-        })
+        lz_n.load(test_plugin)
+        assert.spy(addspy).called_with(test_plugin_loaded)
     end)
     it("loading a plugin removes it from the handler", function()
         lz_n.trigger_load("testplugin")
-        assert.spy(delspy).called_with({
-            name = "testplugin",
-            testfield = { "a", "b" },
-            lazy = true,
-        })
+        assert.spy(delspy).called_with(test_plugin_loaded)
+    end)
+    it("handler after_load is called after load", function()
+        assert.spy(afterspy).called_with(test_plugin_loaded)
+        assert.True(plugin_state["testplugin"].load_called)
+        assert.True(plugin_state["testplugin"].after_load_called_after)
     end)
 end)


### PR DESCRIPTION
New field added to custom handlers to allow things such as handlers which can _automatically_ source the after dirs of plugins after the plugin has been packadded. (before_load is already covered by del)