### PR TITLE
fix: editor config now matches format rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,5 +4,5 @@ root = true
 end_of_line = lf
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 trim_trailing_whitespace = true


### PR DESCRIPTION
tab was doing 2 spaces, formatter is configured to 4. Contributors have to hit tab twice for every tab.