### PR TITLE
feat!: simplify state management + idempotent `trigger_load`

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ require("lz.n").register_handler(handler)
 | ---        | ---                                 | ---                                                       |
 | spec_field | `string`                            | the `lz.n.PluginSpec` field used to configure the handler |
 | add        | `fun(plugin: lz.n.Plugin)`          | adds a plugin to the handler                              |
-| del        | `fun(plugin: lz.n.Plugin)`          | removes a plugin from the handler                         |
+| del        | `fun(name: string)`                 | removes a plugin from the handler by name                 |
 | lookup     | `fun(name: string):lz.n.Plugin?`    | lookup a plugin managed by this handler by name           |
 <!-- markdownlint-enable MD013 -->
 

--- a/lua/lz/n/handler/cmd.lua
+++ b/lua/lz/n/handler/cmd.lua
@@ -4,9 +4,16 @@ local loader = require("lz.n.loader")
 
 ---@type lz.n.CmdHandler
 local M = {
+    ---@type table<string, table<string, lz.n.Plugin[]>>
     pending = {},
     spec_field = "cmd",
 }
+
+---@param name string
+---@return lz.n.Plugin?
+function M.lookup(name)
+    return require("lz.n.handler.extra").lookup(M.pending, name)
+end
 
 ---@param cmd string
 local function load(cmd)
@@ -82,7 +89,7 @@ function M.add(plugin)
     ---@param cmd string
     vim.iter(plugin.cmd):each(function(cmd)
         M.pending[cmd] = M.pending[cmd] or {}
-        M.pending[cmd][plugin.name] = plugin.name
+        M.pending[cmd][plugin.name] = plugin
         add_cmd(cmd)
     end)
 end

--- a/lua/lz/n/handler/cmd.lua
+++ b/lua/lz/n/handler/cmd.lua
@@ -73,12 +73,16 @@ local function add_cmd(cmd)
     })
 end
 
----@param plugin lz.n.Plugin
-function M.del(plugin)
-    pcall(vim.api.nvim_del_user_command, plugin.cmd)
-    vim.iter(M.pending):each(function(_, plugins)
-        plugins[plugin.name] = nil
-    end)
+---@param name string
+function M.del(name)
+    vim.iter(M.pending)
+        :filter(function(_, plugins)
+            return plugins[name] ~= nil
+        end)
+        :each(function(cmd, plugins)
+            pcall(vim.api.nvim_del_user_command, cmd)
+            plugins[name] = nil
+        end)
 end
 
 ---@param plugin lz.n.Plugin

--- a/lua/lz/n/handler/colorscheme.lua
+++ b/lua/lz/n/handler/colorscheme.lua
@@ -5,10 +5,17 @@ local loader = require("lz.n.loader")
 
 ---@type lz.n.ColorschemeHandler
 local M = {
+    ---@type table<string, table<string, lz.n.Plugin[]>>
     pending = {},
     augroup = nil,
     spec_field = "colorscheme",
 }
+
+---@param name string
+---@return lz.n.Plugin?
+function M.lookup(name)
+    return require("lz.n.handler.extra").lookup(M.pending, name)
+end
 
 ---@param plugin lz.n.Plugin
 function M.del(plugin)
@@ -49,7 +56,7 @@ function M.add(plugin)
     ---@param colorscheme string
     vim.iter(plugin.colorscheme):each(function(colorscheme)
         M.pending[colorscheme] = M.pending[colorscheme] or {}
-        M.pending[colorscheme][plugin.name] = plugin.name
+        M.pending[colorscheme][plugin.name] = plugin
     end)
 end
 

--- a/lua/lz/n/handler/colorscheme.lua
+++ b/lua/lz/n/handler/colorscheme.lua
@@ -17,10 +17,10 @@ function M.lookup(name)
     return require("lz.n.handler.extra").lookup(M.pending, name)
 end
 
----@param plugin lz.n.Plugin
-function M.del(plugin)
+---@param name string
+function M.del(name)
     vim.iter(M.pending):each(function(_, plugins)
-        plugins[plugin.name] = nil
+        plugins[name] = nil
     end)
 end
 

--- a/lua/lz/n/handler/event.lua
+++ b/lua/lz/n/handler/event.lua
@@ -178,10 +178,10 @@ function M.add(plugin)
     end)
 end
 
----@param plugin lz.n.Plugin
-function M.del(plugin)
+---@param name string
+function M.del(name)
     vim.iter(M.pending):each(function(_, plugins)
-        plugins[plugin.name] = nil
+        plugins[name] = nil
     end)
 end
 

--- a/lua/lz/n/handler/event.lua
+++ b/lua/lz/n/handler/event.lua
@@ -20,6 +20,7 @@ lz_n_events["User DeferredUIEnter"] = lz_n_events.DeferredUIEnter
 
 ---@type lz.n.EventHandler
 local M = {
+    ---@type table<string, table<string, lz.n.Plugin[]>>
     pending = {},
     events = {},
     group = vim.api.nvim_create_augroup("lz_n_handler_event", { clear = true }),
@@ -55,6 +56,12 @@ local M = {
         return ret
     end,
 }
+
+---@param name string
+---@return lz.n.Plugin?
+function M.lookup(name)
+    return require("lz.n.handler.extra").lookup(M.pending, name)
+end
 
 -- Get all augroups for an event
 ---@param event string
@@ -166,7 +173,7 @@ function M.add(plugin)
     ---@param event lz.n.Event
     vim.iter(plugin.event or {}):each(function(event)
         M.pending[event.id] = M.pending[event.id] or {}
-        M.pending[event.id][plugin.name] = plugin.name
+        M.pending[event.id][plugin.name] = plugin
         add_event(event)
     end)
 end

--- a/lua/lz/n/handler/extra.lua
+++ b/lua/lz/n/handler/extra.lua
@@ -1,0 +1,23 @@
+---@mod lz.n.handler.extra Helper functions for use by handlers
+
+local M = {}
+
+---Look up a plugin in a plugin table, commonly used by handlers to
+---keep track of plugins they manage
+---@param plugin_tbl table<unknown, table<string, lz.n.Plugin>>
+---@param name string
+---@return lz.n.Plugin?
+function M.lookup(plugin_tbl, name)
+    return vim
+        .iter(plugin_tbl)
+        ---@param plugins table<string, lz.n.Plugin>
+        :map(function(_, plugins)
+            return plugins[name]
+        end)
+        ---@param plugin lz.n.Plugin?
+        :find(function(plugin)
+            return plugin ~= nil
+        end)
+end
+
+return M

--- a/lua/lz/n/handler/ft.lua
+++ b/lua/lz/n/handler/ft.lua
@@ -23,9 +23,9 @@ function M.add(plugin)
     event.add(plugin)
 end
 
----@param plugin lz.n.Plugin
-function M.del(plugin)
-    event.del(plugin)
+---@param name string
+function M.del(name)
+    event.del(name)
 end
 
 return M

--- a/lua/lz/n/handler/ft.lua
+++ b/lua/lz/n/handler/ft.lua
@@ -5,7 +5,6 @@ local event = require("lz.n.handler.event")
 
 ---@type lz.n.FtHandler
 local M = {
-    pending = {},
     spec_field = "ft",
     ---@param value string
     ---@return lz.n.Event
@@ -16,6 +15,7 @@ local M = {
             pattern = value,
         }
     end,
+    lookup = event.lookup,
 }
 
 ---@param plugin lz.n.Plugin

--- a/lua/lz/n/handler/init.lua
+++ b/lua/lz/n/handler/init.lua
@@ -14,10 +14,6 @@ function M.lookup(name)
     return vim
         .iter(handlers)
         ---@param handler lz.n.Handler
-        :filter(function(_, handler)
-            return type(handler.lookup) == "function"
-        end)
-        ---@param handler lz.n.Handler
         :map(function(_, handler)
             return handler.lookup(name)
         end)
@@ -60,12 +56,11 @@ local function enable(plugin)
     end)
 end
 
-function M.disable(plugin)
+---@param name string
+function M.disable(name)
     ---@param handler lz.n.Handler
     vim.iter(handlers):each(function(_, handler)
-        if handler.del then
-            handler.del(plugin)
-        end
+        handler.del(name)
     end)
 end
 

--- a/lua/lz/n/handler/init.lua
+++ b/lua/lz/n/handler/init.lua
@@ -8,6 +8,25 @@ local handlers = {
     colorscheme = require("lz.n.handler.colorscheme"),
 }
 
+---@param name string
+---@return lz.n.Plugin?
+function M.lookup(name)
+    return vim
+        .iter(handlers)
+        ---@param handler lz.n.Handler
+        :filter(function(_, handler)
+            return type(handler.lookup) == "function"
+        end)
+        ---@param handler lz.n.Handler
+        :map(function(_, handler)
+            return handler.lookup(name)
+        end)
+        ---@param result lz.n.Plugin?
+        :find(function(result)
+            return result ~= nil
+        end)
+end
+
 ---@param spec lz.n.PluginSpec
 ---@return boolean
 function M.is_lazy(spec)

--- a/lua/lz/n/handler/keys.lua
+++ b/lua/lz/n/handler/keys.lua
@@ -25,6 +25,7 @@ end
 
 ---@type lz.n.KeysHandler
 local M = {
+    ---@type table<string, table<string, lz.n.Plugin[]>>
     pending = {},
     spec_field = "keys",
     ---@param value string|lz.n.KeysSpec
@@ -42,6 +43,12 @@ local M = {
             :totable()
     end,
 }
+
+---@param name string
+---@return lz.n.Plugin?
+function M.lookup(name)
+    return require("lz.n.handler.extra").lookup(M.pending, name)
+end
 
 local skip = { mode = true, id = true, ft = true, rhs = true, lhs = true }
 
@@ -142,7 +149,7 @@ function M.add(plugin)
     ---@param key lz.n.Keys
     vim.iter(plugin.keys or {}):each(function(key)
         M.pending[key.id] = M.pending[key.id] or {}
-        M.pending[key.id][plugin.name] = plugin.name
+        M.pending[key.id][plugin.name] = plugin
         add_keys(key)
     end)
 end

--- a/lua/lz/n/handler/keys.lua
+++ b/lua/lz/n/handler/keys.lua
@@ -154,10 +154,10 @@ function M.add(plugin)
     end)
 end
 
----@param plugin lz.n.Plugin
-function M.del(plugin)
+---@param name string
+function M.del(name)
     vim.iter(M.pending):each(function(_, plugins)
-        plugins[plugin.name] = nil
+        plugins[name] = nil
     end)
 end
 

--- a/lua/lz/n/loader.lua
+++ b/lua/lz/n/loader.lua
@@ -12,7 +12,7 @@ function M._load(plugin)
     if plugin.enabled == false or (type(plugin.enabled) == "function" and not plugin.enabled()) then
         return
     end
-    require("lz.n.handler").disable(plugin)
+    require("lz.n.handler").disable(plugin.name)
     ---@type fun(name: string) | nil
     local load_impl = plugin.load or vim.tbl_get(vim.g, "lz_n", "load")
     if type(load_impl) == "function" then

--- a/lua/lz/n/loader.lua
+++ b/lua/lz/n/loader.lua
@@ -1,7 +1,5 @@
 ---@mod lz.n.loader
 
-local state = require("lz.n.state")
-
 local M = {}
 
 local DEFAULT_PRIORITY = 50
@@ -101,7 +99,8 @@ local function hook(hook_key, plugin)
 end
 
 ---@param plugins string | lz.n.Plugin | string[] | lz.n.Plugin[]
-function M.load(plugins)
+---@param lookup? fun(name: string): lz.n.Plugin?
+function M.load(plugins, lookup)
     plugins = (type(plugins) == "string" or plugins.name) and { plugins } or plugins
     ---@cast plugins (string|lz.n.Plugin)[]
     for _, plugin in pairs(plugins) do
@@ -109,9 +108,8 @@ function M.load(plugins)
         -- https://github.com/nvim-neorocks/lz.n/pull/21
         local loadable = true
         if type(plugin) == "string" then
-            if state.plugins[plugin] then
-                plugin = state.plugins[plugin]
-            else
+            plugin = lookup and lookup(plugin) or plugin
+            if type(plugin) == "string" then
                 vim.notify("Plugin " .. plugin .. " not found", vim.log.levels.ERROR, { title = "lz.n" })
                 loadable = false
             end

--- a/lua/lz/n/meta.lua
+++ b/lua/lz/n/meta.lua
@@ -96,8 +96,8 @@ error("Cannot import a meta module")
 --- Add a plugin to this handler.
 --- @field add fun(plugin: lz.n.Plugin)
 ---
---- Remove a plugin from this handler.
---- @field del fun(plugin: lz.n.Plugin)
+--- Remove a plugin from this handler by name.
+--- @field del fun(name: string)
 ---
 --- Lookup a plugin by name.
 --- @field lookup fun(name: string): lz.n.Plugin?

--- a/lua/lz/n/meta.lua
+++ b/lua/lz/n/meta.lua
@@ -89,9 +89,18 @@ error("Cannot import a meta module")
 --- @field load? fun(name: string)
 
 --- @class lz.n.Handler
+---
+--- The |lz.n.PluginSpec| field used to configure this handler.
 --- @field spec_field string
+---
+--- Add a plugin to this handler.
 --- @field add fun(plugin: lz.n.Plugin)
---- @field del? fun(plugin: lz.n.Plugin)
+---
+--- Remove a plugin from this handler.
+--- @field del fun(plugin: lz.n.Plugin)
+---
+--- Lookup a plugin by name.
+--- @field lookup fun(name: string): lz.n.Plugin?
 
 --- @type lz.n.Config
 vim.g.lz_n = vim.g.lz_n

--- a/lua/lz/n/state.lua
+++ b/lua/lz/n/state.lua
@@ -1,8 +1,0 @@
----@mod lz.n.state
-
-local M = {}
-
----@type table<string, lz.n.Plugin>
-M.plugins = {}
-
-return M

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -3,7 +3,6 @@ vim.g.lz_n = {
     load = function() end,
 }
 local cmd = require("lz.n.handler.cmd")
-local state = require("lz.n.state")
 local loader = require("lz.n.loader")
 local spy = require("luassert.spy")
 
@@ -15,7 +14,6 @@ describe("handlers.cmd", function()
             cmd = { "Foo" },
         }
         local spy_load = spy.on(loader, "_load")
-        state.plugins[plugin.name] = plugin
         cmd.add(plugin)
         assert.is_not_nil(vim.cmd.Foo)
         local counter = 0
@@ -49,7 +47,6 @@ describe("handlers.cmd", function()
                 cmd = commands,
             }
             local spy_load = spy.on(loader, "_load")
-            state.plugins[plugin.name] = plugin
             cmd.add(plugin)
             vim.cmd[commands[1]]()
             vim.cmd[commands[2]]()

--- a/spec/colorscheme_spec.lua
+++ b/spec/colorscheme_spec.lua
@@ -2,7 +2,6 @@ vim.g.lz_n = {
     load = function() end,
 }
 local colorscheme = require("lz.n.handler.colorscheme")
-local state = require("lz.n.state")
 local loader = require("lz.n.loader")
 local spy = require("luassert.spy")
 
@@ -14,7 +13,6 @@ describe("handlers.colorscheme", function()
             colorscheme = { "sweetie" },
         }
         local spy_load = spy.on(loader, "_load")
-        state.plugins[plugin.name] = plugin
         colorscheme.add(plugin)
         pcall(vim.cmd.colorscheme, "sweetie")
         pcall(vim.cmd.colorscheme, "sweetie")

--- a/spec/event_spec.lua
+++ b/spec/event_spec.lua
@@ -3,7 +3,6 @@ vim.g.lz_n = {
     load = function() end,
 }
 local event = require("lz.n.handler.event")
-local state = require("lz.n.state")
 local loader = require("lz.n.loader")
 local spy = require("luassert.spy")
 
@@ -52,7 +51,6 @@ describe("handlers.event", function()
             event = { event.parse("BufEnter") },
         }
         local spy_load = spy.on(loader, "_load")
-        state.plugins[plugin.name] = plugin
         event.add(plugin)
         vim.api.nvim_exec_autocmds("BufEnter", {})
         vim.api.nvim_exec_autocmds("BufEnter", {})
@@ -67,7 +65,6 @@ describe("handlers.event", function()
                 event = events,
             }
             local spy_load = spy.on(loader, "_load")
-            state.plugins[plugin.name] = plugin
             event.add(plugin)
             vim.api.nvim_exec_autocmds(events[1].event, {
                 pattern = ".lua",
@@ -98,7 +95,6 @@ describe("handlers.event", function()
                 group = vim.api.nvim_create_augroup("foo", {}),
             })
         end
-        state.plugins[plugin.name] = plugin
         event.add(plugin)
         vim.api.nvim_exec_autocmds("BufEnter", {})
         assert.True(triggered)
@@ -111,7 +107,6 @@ describe("handlers.event", function()
             event = { event.parse("DeferredUIEnter") },
         }
         local spy_load = spy.on(loader, "_load")
-        state.plugins[plugin.name] = plugin
         event.add(plugin)
         vim.api.nvim_exec_autocmds("User", { pattern = "DeferredUIEnter", modeline = false })
         assert.spy(spy_load).called(1)

--- a/spec/ft_spec.lua
+++ b/spec/ft_spec.lua
@@ -3,7 +3,6 @@ vim.g.lz_n = {
     load = function() end,
 }
 local ft = require("lz.n.handler.ft")
-local state = require("lz.n.state")
 local loader = require("lz.n.loader")
 local spy = require("luassert.spy")
 
@@ -22,7 +21,6 @@ describe("handlers.ft", function()
             event = { ft.parse("rust") },
         }
         local spy_load = spy.on(loader, "_load")
-        state.plugins[plugin.name] = plugin
         ft.add(plugin)
         vim.api.nvim_exec_autocmds("FileType", { pattern = "rust" })
         vim.api.nvim_exec_autocmds("FileType", { pattern = "rust" })

--- a/spec/keys_spec.lua
+++ b/spec/keys_spec.lua
@@ -3,7 +3,6 @@ vim.g.lz_n = {
     load = function() end,
 }
 local keys = require("lz.n.handler.keys")
-local state = require("lz.n.state")
 local loader = require("lz.n.loader")
 local spy = require("luassert.spy")
 
@@ -30,7 +29,6 @@ describe("handlers.keys", function()
             keys = keys.parse(lhs),
         }
         local spy_load = spy.on(loader, "_load")
-        state.plugins[plugin.name] = plugin
         keys.add(plugin)
         local feed = vim.api.nvim_replace_termcodes("<Ignore>" .. lhs, true, true, true)
         vim.api.nvim_feedkeys(feed, "ix", false)
@@ -47,7 +45,6 @@ describe("handlers.keys", function()
                 keys = lzkeys,
             }
             local spy_load = spy.on(loader, "_load")
-            state.plugins[plugin.name] = plugin
             keys.add(plugin)
             local feed1 = vim.api.nvim_replace_termcodes("<Ignore>" .. lzkeys[1].lhs, true, true, true)
             vim.api.nvim_feedkeys(feed1, "ix", false)
@@ -74,7 +71,6 @@ describe("handlers.keys", function()
             end)
             orig_load(...)
         end
-        state.plugins[plugin.name] = plugin
         keys.add(plugin)
         local feed = vim.api.nvim_replace_termcodes("<Ignore>" .. lhs, true, true, true)
         vim.api.nvim_feedkeys(feed, "ix", false)

--- a/spec/register_handler_spec.lua
+++ b/spec/register_handler_spec.lua
@@ -5,16 +5,34 @@ vim.g.lz_n = {
 local lz_n = require("lz.n")
 local spy = require("luassert.spy")
 
+---@type lz.n.Plugin
+local testplugin = {
+    name = "testplugin",
+    testfield = { "a", "b" },
+    lazy = true,
+}
+
 describe("handlers.custom", function()
     ---@class TestHandler: lz.n.Handler
+    local mock_state = {}
     ---@type TestHandler
-    local hndl = {
+    local mock_hndl = {
         spec_field = "testfield",
-        add = function(_) end,
-        del = function(_) end,
+        add = function(plugin)
+            mock_state[plugin.name] = plugin
+        end,
+        del = function(plugin)
+            mock_state[plugin.name] = nil
+        end,
+        ---@param name string
+        ---@return lz.n.Plugin?
+        lookup = function(name)
+            return mock_state[name]
+        end,
     }
-    local addspy = spy.on(hndl, "add")
-    local delspy = spy.on(hndl, "del")
+
+    local addspy = spy.on(mock_hndl, "add")
+    local delspy = spy.on(mock_hndl, "del")
     it("Duplicate handlers fail to register", function()
         local notispy = spy.new(function() end)
         -- NOTE: teardown fails if you don't temporarily replace vim.notify
@@ -25,23 +43,19 @@ describe("handlers.custom", function()
         vim.notify = og_notify
     end)
     it("can add plugins to the handler", function()
-        assert.True(lz_n.register_handler(hndl))
+        assert.True(lz_n.register_handler(mock_hndl))
         lz_n.load({
             "testplugin",
             testfield = { "a", "b" },
         })
-        assert.spy(addspy).called_with({
-            name = "testplugin",
-            testfield = { "a", "b" },
-            lazy = true,
-        })
+        assert.spy(addspy).called_with(testplugin)
     end)
     it("loading a plugin removes it from the handler", function()
-        lz_n.trigger_load("testplugin")
-        assert.spy(delspy).called_with({
-            name = "testplugin",
-            testfield = { "a", "b" },
-            lazy = true,
-        })
+        lz_n.trigger_load(testplugin.name)
+        assert.spy(delspy).called_with(testplugin)
+    end)
+    it("trigger_load is idempotent when called with a plugin name", function()
+        lz_n.trigger_load(testplugin.name)
+        assert.spy(delspy).called(1)
     end)
 end)

--- a/spec/register_handler_spec.lua
+++ b/spec/register_handler_spec.lua
@@ -21,8 +21,9 @@ describe("handlers.custom", function()
         add = function(plugin)
             mock_state[plugin.name] = plugin
         end,
-        del = function(plugin)
-            mock_state[plugin.name] = nil
+        ---@param name string
+        del = function(name)
+            mock_state[name] = nil
         end,
         ---@param name string
         ---@return lz.n.Plugin?
@@ -52,7 +53,7 @@ describe("handlers.custom", function()
     end)
     it("loading a plugin removes it from the handler", function()
         lz_n.trigger_load(testplugin.name)
-        assert.spy(delspy).called_with(testplugin)
+        assert.spy(delspy).called_with(testplugin.name)
     end)
     it("trigger_load is idempotent when called with a plugin name", function()
         lz_n.trigger_load(testplugin.name)


### PR DESCRIPTION
Closes #51.

CC @BirdeeHub @horriblename.

This is a breaking change:

- I have removed the `lz.n.state` module (which was a second source of truth).
  It is now the responsibility of `lz.n.Handler`s to communicate whether a `lz.n.Plugin` is pending to be loaded by them via their (optional) `lookup` function `---@type (fun(name: string):lz.n.Plugin?`).
  Because of this, `lz.n.Handler.del` is no longer optional, and it takes a plugin name (`string`) instead of a `lz.n.Plugin`.
- `lz.n.state` was never part of the public API, so its removal technically isn't a breaking change, but it will
  break `lzn-auto-require`. Instead of using the `state` module, you can use `require("lz.n").lookup` to find out if a plugin is pending to be loaded (it will pick the first one it finds).
  
> [!IMPORTANT]
>
> Anything that is not exposed via the `lz.n` module is not part of the public API
> and subject to change without a major version bump.
  
- The `trigger_load` function is now idempotent. When passing in a plugin name, it will use `lookup` to find a pending plugin and load it, removing it from all handlers after loading.
  So you cannot load a plugin more than once with `trigger_load(name: string)`.
  This may be useful for loading plugins in another plugin's `before` or `after` hooks.
However, if you call `trigger_load(plugin: lz.n.Plugin)` (typically done within a handler), it will not perform any lookups and will just load the plugin that was passed to it (regardless of whether it has been loaded before). In this case it's the caller's responsibility to prevent itself from loading a plugin multiple times (if that's the desired behaviour).
- With the removal of `lz.n.state`, I have also removed the checks to prevent you from registering conflicting plugin specs with multiple `load` calls (YAGNI).
  If this turns out to cause unexpected problems, we can add checks on a per-handler basis at a later time (e.g. in the `add` functions.
  In any case, preventing conflicting handler configurations will be the respective handlers' responsibilities.

I will leave this PR open to give you time to adapt your extensions/configs.
Please let me know when you are ready for this to be released :smile: 

P.S. you can test this with Nix by importing the flake:

```nix
{
  inputs.lz-n = "github:nvim-neorocks/lz.n?ref=rm-state";
  # lz-n.packages.${system}.default is a vimPlugin
}
```

or without Nix by cloning the `rm-state` branch.