### PR TITLE
feat(`load`): take first module when multiple matches exist on the rtp

### DIFF
--- a/lua/lz/n/spec.lua
+++ b/lua/lz/n/spec.lua
@@ -50,7 +50,7 @@ local function import_spec(spec, result)
         import_modname(modname, result)
     end
     local import_dir = vim.api.nvim_get_runtime_file(vim.fs.joinpath("lua", modname), true)
-    if #import_dir == 1 then
+    if #import_dir > 0 then
         local dir = import_dir[1]
         local handle = vim.uv.fs_scandir(dir)
         while handle do


### PR DESCRIPTION
Hi, I'm building out a new nvim config for myself as a flake, and trying out using this, https://github.com/Gerg-L/mnw, and npins for all the plugins. 

It's going well so far (loving lz.n thanks!), but it is annoying to have to do a nix build to try out small changes. I realized though as long as I'm just modifying my local config and not adding/updating/removing any plugins, it's not strictly necessary to write anything new to the nix store if I prepend the local config dir to the vim runtimepath.

Following @Gerg-L's example in https://github.com/Gerg-L/nvim-flake I have a `will/lua/` dir that has a `will` dir for my `init.lua` file, then for lz.n I also have a `plugins` directory and am just doing `require("lz.n").load("plugins")`  in `will/init.lua`.

Then to test out local changes without a nix build, I can mostly do `result/bin/nvim --cmd 'set rtp^=will'` , except now there are two `plugins` modules in the RTP, and prior to this patch, lz.n wouldn't load either. By taking the first one, I can now iterate on my local config much quicker.