### PR TITLE
docs: explain lua submodule usage in `load()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,9 @@ Or
   ├── init.lua
 ```
 
+> [!WARNING]
+> When using submodules, ensure you use `/` as a separator (i.e., `parent/submodule` over `parent.submodule`)
+
 ## :electric_plug: API
 
 ### Custom handlers

--- a/doc/lz.n.txt
+++ b/doc/lz.n.txt
@@ -53,7 +53,9 @@ M.load()                                                                *M.load*
     Register a list with your plugin specs or a single plugin spec to be lazy-loaded.
 
     @overload fun(import: string)
-    Register a Lua module name that contains your plugin spec(s) to be lazy-loaded.
+    Register a Lua module name that contains your plugin spec(s) to be
+    lazy-loaded. When using submodules, ensure you use `/` as a separator
+    (i.e., `parent/submodule` over `parent.submodule`).
 
 
 M.lookup({name}, {opts?})                                             *M.lookup*


### PR DESCRIPTION
From the [docs](https://github.com/nvim-neorocks/lz.n/blob/d3f6efdcca22a266f107cf0f35272275f495fba5/doc/lz.n.txt#L55-L56):

> Register a ***Lua module name*** that contains your plugin spec(s) to be lazy-loaded.

In most cases this will work as expected, as you'll be using a root level lua module (i.e., `plugins` in the README's [example](https://github.com/nvim-neorocks/lz.n/blob/d3f6efdcca22a266f107cf0f35272275f495fba5/README.md#structuring-your-plugins)). However, if you try to use a submodule in the regular form of `parent.submodule`, `load()` will silently fail and not load anything; to work around this, you must instead pass a string like `"parent/submodule"`

[Here's](https://github.com/nvim-neorocks/lz.n/blob/d3f6efdcca22a266f107cf0f35272275f495fba5/lua/lz/n/spec.lua#L52) the line responsible, where the string is combined with the `lua/` path to search for directories in your runtimepath. The documentation now warns of this inconsistency
