### PR TITLE
feat: support explicit lazy=false

### DIFF
--- a/lua/lz/n/handler/init.lua
+++ b/lua/lz/n/handler/init.lua
@@ -93,13 +93,16 @@ end
 ---@return boolean
 local function is_lazy(spec)
     ---@diagnostic disable-next-line: undefined-field
-    return spec.lazy
-        or vim.iter(handlers):any(function(spec_field, _)
-            -- PERF: This should be simpler and more performant than
-            -- filtering out "lazy" spec fields. However, this also
-            -- assumes that 'false' means a handler is disabled.
-            return spec[spec_field] and spec[spec_field] ~= nil
-        end)
+    if spec.lazy ~= nil then
+        ---@diagnostic disable-next-line: undefined-field
+        return spec.lazy
+    end
+    return vim.iter(handlers):any(function(spec_field, _)
+        -- PERF: This should be simpler and more performant than
+        -- filtering out "lazy" spec fields. However, this also
+        -- assumes that 'false' means a handler is disabled.
+        return spec[spec_field] and spec[spec_field] ~= nil
+    end)
 end
 
 ---Mutates the `plugin`.

--- a/spec/lz_n_spec.lua
+++ b/spec/lz_n_spec.lua
@@ -96,5 +96,21 @@ describe("lz.n", function()
                 cmd = { "Single" },
             })
         end)
+        it("eagerly load if lazy=False", function()
+            local spy_load = spy.on(loader, "_load")
+            lz.load({
+                {
+                    "single.nvim",
+                    cmd = "Single",
+                    lazy = false,
+                },
+            })
+            assert.spy(spy_load).called(1)
+            assert.spy(spy_load).called_with({
+                name = "single.nvim",
+                cmd = { "Single" },
+                lazy = false,
+            })
+        end)
     end)
 end)


### PR DESCRIPTION
When specifying explicitly `lazy = false` but still keeping a lazy handler (`keys` for example), the `lazy` value is overriden to `true`.

My use case of specifying `lazy = false` is to configure plugins in the `start` directory of my packpath. For example:

```lua
return {
	{
		"oil.nvim",
		lazy = false,
		load = function() end,
		keys = {
			{ "-",    "<CMD>Oil<CR>", desc = "Open parent directory" },
			{ "<BS>", "<CMD>Oil<CR>", desc = "Open parent directory" },
		},
		opts = {
			skip_confirm_for_simple_edits = true,
			view_options = {
				show_hidden = true,
			},
			keymaps = {
				["<BS>"] = "actions.parent",
			},
		},
		after = function(plug)
			require("oil").setup(plug.opts)
		end
	}
}
```