### PR TITLE
feat!: drop Neovim 0.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ It is intended to be used
 > call to a heavy `setup` function,
 > consider opening an issue on the plugin's issue tracker.
 
+## :pencil: Prerequisites
+
+### Required
+
+- `neovim >= 0.12`
+
 ## :star2: Features
 
 - API for lazy-loading plugins on:


### PR DESCRIPTION
> [!NOTE]
>
> This doesn't actually introduce any breaking changes.
> But after #208, CI will no longer ensure compatibility with Neovim 0.11.