### PR TITLE
feat: add DeferredPlugin event

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,12 @@ require("lz.n").load(plugins)
 - `DeferredUIEnter`: Triggered when `load()` is done and after `UIEnter`.
   Can be used as an `event` to lazy-load plugins that are not immediately needed
   for the initial UI[^4].
+- `DeferredPlugin`: Triggered after a particular plugin is fully loaded.
+  The `data` attribute will contain the plugin name. Can be used to run
+  additional setup after a plugin is lazy-loaded outside of its spec[^5].
 
 [^4]: This is equivalent to `lazy.nvim`'s `VeryLazy` event.
+[^5]: This is equivalent to `lazy.nvim`'s `LazyLoad` event.
 
 ### `keymap(<plugin>).set`
 
@@ -305,6 +309,38 @@ require("lz.n").load {
         "dial.nvim",
         -- lazy-load on keys. -- Mode is `n` by default.
         keys = { "<C-a>", { "<C-x>", mode = "n" } },
+    },
+    {
+        "which-key.nvim",
+        event = "DeferredUIEnter",
+        after = function()
+            require("which-key").setup()
+        end,
+    },
+    {
+        "mini.align",
+        lazy = false,
+        after = function()
+            require("mini.align").setup()
+            -- Add additional keymaps to which-key.nvim's menu after it's
+            -- already loaded
+            vim.api.nvim_create_autocmd("User", {
+                pattern = "DeferredPlugin",
+                callback = function(ev)
+                    if ev.data == "which-key.nvim" then
+                        require("which-key").add({
+                            { "ga", desc = "Align text", mode = { "n", "x" } },
+                            {
+                                "gA",
+                                desc = "Align text (preview)",
+                                mode = { "n", "x" },
+                            },
+                        })
+                        return true
+                    end
+                end,
+            }),
+        end,
     },
 }
 ```
@@ -476,9 +512,9 @@ return {
 ```
 
 - `lz.n` will automatically merge any Lua file in `~/.config/nvim/lua/plugins/*.lua`
-  with the main plugin spec[^5].
+  with the main plugin spec[^6].
 
-[^5]: It *does not* merge multiple specs for the same plugin from different files.
+[^6]: It *does not* merge multiple specs for the same plugin from different files.
 
 Example structure:
 
@@ -573,7 +609,7 @@ The function provides two overloads, each suited for different use cases:
     - *Description:* This version should be used when working with `lz.n.Handler`
       instances to maintain referential transparency.
       Each handler has full authority over its internal state, ensuring it
-      remains isolated and unaffected by external influences[^6],
+      remains isolated and unaffected by external influences[^7],
       thereby preventing multiple sources of truth.
 2. **Stateful version:**
     - *Usage:* `trigger_load(plugin_name: string | string[], opts?: lz.n.lookup.Opts)`
@@ -586,7 +622,7 @@ The function provides two overloads, each suited for different use cases:
       to identify an appropriate plugin, and returns the first match.
       You can fine-tune the search process by providing a [`lz.n.lookup.Opts` table](#lookup).
 
-[^6]: Until the handler is instructed to stop tracking a loaded plugin via its `del` function.
+[^7]: Until the handler is instructed to stop tracking a loaded plugin via its `del` function.
 
 #### `lookup`
 

--- a/lua/lz/n/loader.lua
+++ b/lua/lz/n/loader.lua
@@ -134,6 +134,9 @@ function M.load(plugins, lookup)
             hook("before", plugin)
             M._load(plugin)
             hook("after", plugin)
+            vim.schedule(function()
+                vim.api.nvim_exec_autocmds("User", { pattern = "DeferredPlugin", modeline = false, data = plugin.name })
+            end)
         end
     end
     if plugin_spec_count > 1 then

--- a/spec/event_spec.lua
+++ b/spec/event_spec.lua
@@ -113,4 +113,61 @@ describe("handlers.event", function()
         vim.api.nvim_exec_autocmds("User", { pattern = "DeferredUIEnter", modeline = false })
         assert.spy(spy_load).called(1)
     end)
+    it("DeferredPlugin", function()
+        local i = 0
+        while i < 50 do -- make sure it's not flaky
+            i = i + 1
+            local foo_count, bar_count, baz_count = 0, 0, 0
+            require("lz.n").load({
+                {
+                    "foo",
+                    event = "BufEnter",
+                },
+                {
+                    "bar",
+                    event = "BufReadPost",
+                },
+                {
+                    "baz",
+                    event = "BufReadPre",
+                    after = function()
+                        vim.api.nvim_create_autocmd("User", {
+                            pattern = "DeferredPlugin",
+                            callback = function(ev)
+                                if ev.data == "foo" then
+                                    foo_count = foo_count + 1
+                                    return true
+                                end
+                            end,
+                        })
+                        vim.api.nvim_create_autocmd("User", {
+                            pattern = "DeferredPlugin",
+                            callback = function(ev)
+                                if ev.data == "bar" then
+                                    bar_count = bar_count + 1
+                                    return true
+                                end
+                            end,
+                        })
+                    end,
+                },
+            })
+            vim.api.nvim_create_autocmd("User", {
+                pattern = "DeferredPlugin",
+                callback = function(ev)
+                    if ev.data == "baz" then
+                        baz_count = baz_count + 1
+                        return true
+                    end
+                end,
+            })
+            vim.api.nvim_exec_autocmds("BufReadPre", {})
+            vim.api.nvim_exec_autocmds("BufEnter", {})
+            vim.schedule(function()
+                assert.same(1, foo_count)
+                assert.same(0, bar_count)
+                assert.same(1, baz_count)
+            end)
+        end
+    end)
 end)


### PR DESCRIPTION
This is useful when a user wants to configure a plugin (e.g. add additional `which-key.nvim` keys) in another plugin `after()` hook. This pattern is used a lot in https://github.com/LazyVim/LazyVim.